### PR TITLE
make "ht-from-plist" much more convenient for mustache.el

### DIFF
--- a/ht.el
+++ b/ht.el
@@ -86,7 +86,7 @@ Errors if LIST doesn't contain an even number of elements."
   "Create a hash table with initial values according to PLIST."
   (let ((h (ht-create)))
     (dolist (pair (ht/group-pairs plist) h)
-      (let ((key (car pair))
+      (let ((key (substring (symbol-name (car pair)) 1))
             (value (cadr pair)))
         (ht-set h key value)))))
 


### PR DESCRIPTION
For original `ht-from-plist`, it will convert the plist `(:a 1 :b 2)` into the same symbol constructed hashtable, something like `#s ... (:a 1 :b 2)`, it is not friendly for mustache to render templates.

So, I suggest that when doing the conversion, change the plist's key, e.g. `:a`, into string `"a"`, so mustache will work properly with the generated hashtable.
