### PR TITLE
Add optional test argument to ht<-[ap]list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ The missing hash table library for Emacs.
 
 ### Converting to a hash table
 
-* `ht<-alist` `(alist)`
-* `ht<-plist` `(plist)`
+* `ht<-alist` `(alist test?)`
+* `ht<-plist` `(plist test?)`
 
 ## Macros
 

--- a/ht.el
+++ b/ht.el
@@ -51,9 +51,12 @@ keys.  Default is `equal'.  It can be `eq', `eql', `equal' or a
 user-supplied test created via `define-hash-table-test'."
   (make-hash-table :test (or test 'equal)))
 
-(defun ht<-alist (alist)
-  "Create a hash table with initial values according to ALIST."
-  (let ((h (ht-create)))
+(defun ht<-alist (alist &optional test)
+  "Create a hash table with initial values according to ALIST.
+
+Optional argument TEST has the same meaning as for `ht-create'
+and defaults to `equal'."
+  (let ((h (ht-create test)))
     ;; the first key-value pair in an alist gets precedence, so we
     ;; start from the end of the list:
     (dolist (pair (reverse alist) h)
@@ -87,9 +90,12 @@ Errors if LIST doesn't contain an even number of elements."
     (when sublist (error "Expected an even number of elements"))
     (nreverse result)))
 
-(defun ht<-plist (plist)
-  "Create a hash table with initial values according to PLIST."
-  (let ((h (ht-create)))
+(defun ht<-plist (plist &optional test)
+  "Create a hash table with initial values according to PLIST.
+
+Optional argument TEST has the same meaning as for `ht-create'
+and defaults to `equal'."
+  (let ((h (ht-create test)))
     (dolist (pair (ht/group-pairs plist) h)
       (let ((key (car pair))
             (value (cadr pair)))


### PR DESCRIPTION
Backward-compatible API change, I'd suggest minor version bump.

As it stands, ht<-[ap]list cannot be used if you need any comparison other than 'equal'.