### PR TITLE
Add ht-get* nested accessor function

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The missing hash table library for Emacs.
 ### Accessing the hash table
 
 * `ht-get` `(table key default?)`
+* `ht-get*` `(table &rest keys)`
 * `ht-keys` `(table)`
 * `ht-values` `(table)`
 * `ht-items` `(table)`
@@ -115,6 +116,20 @@ This could be alternatively written as:
     (ht-set! greetings "Bob" "Hey Bob!")
     (ht-set! greetings "Chris" "Hi Chris!")
     (ht-get greetings name "Hello stranger!")))
+```
+
+Accessing nested hash tables:
+
+``` emacs-lisp
+(let ((alphabets (ht ("Greek" (ht (1 (ht ('letter "α")
+                                         ('name "alpha")))
+                                  (2 (ht ('letter "β")
+                                         ('name "beta")))))
+                     ("English" (ht (1 (ht ('letter "a")
+                                           ('name "A")))
+                                    (2 (ht ('letter "b")
+                                           ('name "B"))))))))
+  (ht-get* alphabets "Greek" 1 'letter))  ; => "α"
 ```
 
 ## Why?

--- a/ht.el
+++ b/ht.el
@@ -87,6 +87,14 @@ user-supplied test created via `define-hash-table-test'."
 If KEY isn't present, return DEFAULT (nil if not specified)."
   (gethash key table default))
 
+(defun ht-get* (table &rest keys)
+  "Look up KEYS in nested hash tables, starting with TABLE.
+The lookup for each key should return another hash table, except
+for the final key, which may return any value."
+  (if (cdr keys)
+      (apply #'ht-get* (ht-get table (car keys)) (cdr keys))
+    (ht-get table (car keys))))
+
 (defun ht-set! (table key value)
   "Associate KEY in TABLE with VALUE."
   (puthash key value table)

--- a/test/ht-test.el
+++ b/test/ht-test.el
@@ -19,6 +19,22 @@
   (let ((test-table (ht-create)))
     (should (equal (ht-get test-table "foo" "default") "default"))))
 
+(ert-deftest ht-test-get* ()
+  (let ((alphabets (ht ("Greek" (ht (1 (ht ('letter "α")
+                                           ('name "alpha")))
+                                    (2 (ht ('letter "β")
+                                           ('name "beta")))))
+                       ("English" (ht (1 (ht ('letter "a")
+                                             ('name "A")))
+                                      (2 (ht ('letter "b")
+                                             ('name "B"))))))))
+    ;; Nested
+    (should (equal (ht-get* alphabets "English" 1 'letter)
+                   "a"))
+    ;; Non-nested
+    (should (equal (ht-get* (ht (1 "one")) 1)
+                   "one"))))
+
 (ert-deftest ht-test-update ()
   (let ((test-table (ht ("foo" 1))))
     (ht-update test-table (ht ("bar" 2)))


### PR DESCRIPTION
As discussed in #17, this adds `ht-get*` as a function for accessing nested hash tables.