### PR TITLE
Use defsubst where appropriate

### DIFF
--- a/ht.el
+++ b/ht.el
@@ -44,7 +44,7 @@ Keys are compared with `equal'.
        ,@assignments
        ,table-symbol)))
 
-(defun ht-create (&optional test)
+(defsubst ht-create (&optional test)
   "Create an empty hash table.
 
 TEST indicates the function used to compare the hash
@@ -82,7 +82,7 @@ user-supplied test created via `define-hash-table-test'."
 
 (defalias 'ht-from-plist 'ht<-plist)
 
-(defun ht-get (table key &optional default)
+(defsubst ht-get (table key &optional default)
   "Look up KEY in TABLE, and return the matching value.
 If KEY isn't present, return DEFAULT (nil if not specified)."
   (gethash key table default))
@@ -95,7 +95,7 @@ for the final key, which may return any value."
       (apply #'ht-get* (ht-get table (car keys)) (cdr keys))
     (ht-get table (car keys))))
 
-(defun ht-set! (table key value)
+(defsubst ht-set! (table key value)
   "Associate KEY in TABLE with VALUE."
   (puthash key value table)
   nil)
@@ -119,13 +119,13 @@ table is used."
     (mapc (lambda (table) (ht-update! merged table)) tables)
     merged))
 
-(defun ht-remove! (table key)
+(defsubst ht-remove! (table key)
   "Remove KEY from TABLE."
   (remhash key table))
 
 (defalias 'ht-remove 'ht-remove!)
 
-(defun ht-clear! (table)
+(defsubst ht-clear! (table)
   "Remove all keys from TABLE."
   (clrhash table)
   nil)
@@ -191,7 +191,7 @@ inverse of `ht<-plist'.  The following is not guaranteed:
 
 (defalias 'ht-to-plist 'ht->plist)
 
-(defun ht-copy (table)
+(defsubst ht-copy (table)
   "Return a shallow copy of TABLE (keys and values are shared)."
   (copy-hash-table table))
 
@@ -218,11 +218,11 @@ inverse of `ht<-alist'.  The following is not guaranteed:
 
 (defalias 'ht-contains-p 'ht-contains?)
 
-(defun ht-size (table)
+(defsubst ht-size (table)
   "Return the actual number of entries in TABLE."
   (hash-table-count table))
 
-(defun ht-empty? (table)
+(defsubst ht-empty? (table)
   "Return true if the actual number of entries in TABLE is zero."
   (zerop (ht-size table)))
 


### PR DESCRIPTION
To reduce function call overhead.

Tests pass.

I measured a small performance increase in my `pocket-reader` code:

```el
(defmacro elp-profile (times &rest body)
  (declare (indent defun))
  `(let ((prefixes '("pocket-reader"))
         output)
     (dolist (prefix prefixes)
       (elp-instrument-package prefix))
     (dotimes (x ,times)
       ,@body)
     (elp-results)
     (elp-restore-all)
     (point-min)
     (forward-line 20)
     (delete-region (point) (point-max))
     (setq output (buffer-substring-no-properties (point-min) (point-max)))
     (kill-buffer)
     (delete-window)
     (let ((rows (s-lines output)))
       (append (list (list "Function" "Times called" "Total runtime" "Each runtime")
                     'hline)
               (cl-loop for row in rows
                        collect (s-split (rx (1+ space)) row 'omit-nulls))))))

(pocket-reader-unmark-all)
(elp-profile 10
             (pocket-reader--with-pocket-reader-buffer
               (pocket-reader-mark-all)
               (pocket-reader--at-marked-or-current-items
                 (pocket-reader--get-property 'resolved_url))))
```

```org
*** non-defsubst

#+RESULTS:
| Function                                  | Times called | Total runtime | Each runtime |
|-------------------------------------------+--------------+---------------+--------------|
| pocket-reader-mark-all                    |           10 |   0.016361479 | 0.0016361479 |
| pocket-reader--mark-current-item          |         1000 |  0.0116600590 | 1.166...e-05 |
| pocket-reader--item-marked-p              |         1000 |  0.0096563350 | 9.656...e-06 |
| pocket-reader--get-property               |         1000 |  0.0021839849 | 2.183...e-06 |
| pocket-reader--at-item                    |         1000 |  0.0018925269 | 1.892...e-06 |
| pocket-reader--item-visible-p             |         1000 |  0.0014919340 | 1.491...e-06 |
| pocket-reader--with-pocket-reader-buffer  |         1010 |  0.0004760199 | 4.713...e-07 |
| pocket-reader--at-marked-or-current-items |           10 |  1.485...e-05 | 1.485...e-06 |

*** defsubst

#+RESULTS:
| Function                                  | Times called | Total runtime | Each runtime |
|-------------------------------------------+--------------+---------------+--------------|
| pocket-reader-mark-all                    |           10 |   0.015985469 | 0.0015985468 |
| pocket-reader--mark-current-item          |         1000 |  0.0113082080 | 1.130...e-05 |
| pocket-reader--item-marked-p              |         1000 |  0.0092595539 | 9.259...e-06 |
| pocket-reader--get-property               |         1000 |  0.0020602619 | 2.060...e-06 |
| pocket-reader--item-visible-p             |         1000 |   0.001604509 | 1.604509e-06 |
| pocket-reader--at-item                    |         1000 |  0.0014873520 | 1.487352e-06 |
| pocket-reader--with-pocket-reader-buffer  |         1010 |  0.0005507919 | 5.453...e-07 |
| pocket-reader--at-marked-or-current-items |           10 |    1.0496e-05 |   1.0496e-06 |
```