### PR TITLE
Fix ht-get* base case (i.e., empty list of keys)

### DIFF
--- a/ht.el
+++ b/ht.el
@@ -103,7 +103,9 @@ The lookup for each key should return another hash table, except
 for the final key, which may return any value."
   (if (cdr keys)
       (apply #'ht-get* (ht-get table (car keys)) (cdr keys))
-    (ht-get table (car keys))))
+    (if keys
+        (ht-get table (car keys))
+      table)))
 
 (gv-define-setter ht-get* (value table &rest keys)
   `(if (cdr ',keys)

--- a/test/ht-test.el
+++ b/test/ht-test.el
@@ -33,7 +33,10 @@
                    "a"))
     ;; Non-nested
     (should (equal (ht-get* (ht (1 "one")) 1)
-                   "one"))))
+                   "one"))
+    ;; Base case (no keys)
+    (should (equal (ht-get* alphabets)
+                   alphabets))))
 
 (ert-deftest ht-test-setf-ht-get ()
   (let ((test-table (ht (1 "one") (2 "two"))))
@@ -46,7 +49,17 @@
   (let ((test-table (ht (1 (ht (2 (ht (3 "three"))))))))
     (setf (ht-get* test-table 1 2 3) "gamma")
     (should (equal (ht-get* test-table 1 2 3)
-                   "gamma"))))
+                   "gamma")))
+  ;; nested tables { 1 : { 2 : two } }
+  (let ((test-table (ht (1 (ht (2 "two"))))))
+    (setf (ht-get* test-table 1 2) "beta")
+    (should (equal (ht-get* test-table 1 2)
+                   "beta")))
+  ;; Non-nested table { 1 : one }
+  (let ((test-table (ht (1 "one"))))
+    (setf (ht-get* test-table 1) "alpha")
+    (should (equal (ht-get* test-table 1)
+                   "alpha"))))
 
 (ert-deftest ht-test-update ()
   (let ((test-table (ht ("foo" 1))))


### PR DESCRIPTION
Before this commit, the setter method for `ht-get*` would fail if the list of keys were of length 2.

Follow-up to #26.

* `ht.el` (`ht-get*`): If `keys` is empty, return the table.
* `test/ht-test.el` (`ht-test-get*`): Test `ht-get*` with no keys.
(`ht-test-setf-ht-get*`): Test `(setf (ht-get* ...) ...)` with two keys and with one key.

---

This change does not handle `(setf (ht-get* table) value)`, which logically should set `table` to `value`, but this is an edge case and is not as easy to fix: The obvious approach of simply doing `(setq ,table ,value)` in the setter method if `',keys` is null does not change the value of `table`.