### PR TITLE
Enable lexical-binding

### DIFF
--- a/ht.el
+++ b/ht.el
@@ -1,4 +1,4 @@
-;;; ht.el --- The missing hash table library for Emacs
+;;; ht.el --- The missing hash table library for Emacs  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2013 Wilfred Hughes
 

--- a/ht.el
+++ b/ht.el
@@ -101,6 +101,9 @@ If KEY isn't present, return DEFAULT (nil if not specified)."
   "Look up KEYS in nested hash tables, starting with TABLE.
 The lookup for each key should return another hash table, except
 for the final key, which may return any value."
+  (declare (compiler-macro
+            (lambda (_)
+              (--reduce-from `(ht-get ,acc ,it) table keys))))
   (while keys
     (setf table (ht-get table (pop keys))))
   table)

--- a/ht.el
+++ b/ht.el
@@ -101,11 +101,9 @@ If KEY isn't present, return DEFAULT (nil if not specified)."
   "Look up KEYS in nested hash tables, starting with TABLE.
 The lookup for each key should return another hash table, except
 for the final key, which may return any value."
-  (if (cdr keys)
-      (apply #'ht-get* (ht-get table (car keys)) (cdr keys))
-    (if keys
-        (ht-get table (car keys))
-      table)))
+  (while keys
+    (setf table (ht-get table (pop keys))))
+  table)
 
 (gv-define-setter ht-get* (value table &rest keys)
   `(if (cdr ',keys)


### PR DESCRIPTION
I don't see any reason why `lexical-binding` shouldn't be used, but if there is a reason then feel free to ignore.

I also modified `ht-get*` a bit, to use a simple `while` loop instead of recursion, which IMO looks cleaner,  and should be faster (haven't tested performance). Also added a compiler macro, which eliminates all iteration.

There's more changes I'd like to submit, like making the gv setter for `ht-get*` evaluate the keys (which seems like the way it's supposed to work, no?), so let me know if you're interested.