### PR TITLE
Feat/resupport 24.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
   - evm install $EVM_EMACS --use --skip
   - cask
 env:
+  - EVM_EMACS=emacs-24.3-travis
   - EVM_EMACS=emacs-24.4-travis
   - EVM_EMACS=emacs-24.5-travis
   - EVM_EMACS=emacs-25.1-travis

--- a/ht.el
+++ b/ht.el
@@ -95,7 +95,9 @@ user-supplied test created via `define-hash-table-test'."
 If KEY isn't present, return DEFAULT (nil if not specified)."
   (gethash key table default))
 
-(gv-define-setter ht-get (value table key) `(ht-set! ,table ,key ,value))
+;; Don't use `ht-set!' here, gv setter was assumed to return the value
+;; to be set.
+(gv-define-setter ht-get (value table key) `(puthash ,key ,value ,table))
 
 (defun ht-get* (table &rest keys)
   "Look up KEYS in nested hash tables, starting with TABLE.

--- a/ht.el
+++ b/ht.el
@@ -101,12 +101,13 @@ If KEY isn't present, return DEFAULT (nil if not specified)."
   "Look up KEYS in nested hash tables, starting with TABLE.
 The lookup for each key should return another hash table, except
 for the final key, which may return any value."
-  (declare (compiler-macro
-            (lambda (_)
-              (--reduce-from `(ht-get ,acc ,it) table keys))))
   (while keys
     (setf table (ht-get table (pop keys))))
   table)
+
+(put 'ht-get* 'compiler-macro
+     (lambda (_ table &rest keys)
+       (--reduce-from `(ht-get ,acc ,it) table keys)))
 
 (gv-define-setter ht-get* (value table &rest keys)
   `(if (cdr ',keys)

--- a/ht.el
+++ b/ht.el
@@ -109,15 +109,6 @@ for the final key, which may return any value."
      (lambda (_ table &rest keys)
        (--reduce-from `(ht-get ,acc ,it) table keys)))
 
-(gv-define-setter ht-get* (value table &rest keys)
-  `(if (cdr ',keys)
-       (let* ((first-key (car ',keys))
-              (last-key (-last-item ',keys))
-              (butlast-key (butlast (cdr ',keys)))
-              (h (apply #'ht-get* (ht-get ,table first-key) butlast-key)))
-         (ht-set! h last-key ,value))
-     (ht-set! ,table (car ',keys) ,value)))
-
 (defun ht-update! (table from-table)
   "Update TABLE according to every key-value pair in FROM-TABLE."
   (maphash

--- a/test/ht-test.el
+++ b/test/ht-test.el
@@ -39,12 +39,19 @@
                    alphabets))))
 
 (ert-deftest ht-test-setf-ht-get ()
+  (let ((test-table (ht (1 "one"))))
+    (should (equal (setf (ht-get test-table 1) "alpha") "alpha")))
+
   (let ((test-table (ht (1 "one") (2 "two"))))
     (setf (ht-get test-table 1)  "alpha")
     (should (equal (ht-get test-table 1)
                    "alpha"))))
 
 (ert-deftest ht-test-setf-ht-get* ()
+  (let ((test-table (ht (1 (ht (2 (ht (3 "three"))))))))
+    (should (equal (setf (ht-get* test-table 1 2 3) "gamma")
+                   "gamma")))
+
   ;; nested tables { 1 : { 2 : { 3 : three } } }
   (let ((test-table (ht (1 (ht (2 (ht (3 "three"))))))))
     (setf (ht-get* test-table 1 2 3) "gamma")


### PR DESCRIPTION
https://github.com/Wilfred/ht.el/commit/077b5ea3aeb72fba16e3287545042211e541c6fb break Emacs 24.3 support, but we don't need to drop it because Emacs 24.3 just doesn't support defining compiler-macro in `declare` form, we can set it manually.