### PR TITLE
Fix return behaviour of ht-get*.

### DIFF
--- a/ht.el
+++ b/ht.el
@@ -114,9 +114,10 @@ for the final key, which may return any value."
   (declare (side-effect-free t))
   (inline-letevals (table keys)
     (inline-quote
-     (prog1 ,table
+     (progn
        (while ,keys
-         (setf ,table (ht-get table (pop ,keys))))))))
+         (setf ,table (ht-get ,table (pop ,keys))))
+       ,table))))
 
 (put 'ht-get* 'compiler-macro
      (lambda (_ table &rest keys)

--- a/test/ht-test.el
+++ b/test/ht-test.el
@@ -36,7 +36,10 @@
                    "one"))
     ;; Base case (no keys)
     (should (equal (ht-get* alphabets)
-                   alphabets))))
+                   alphabets))
+    ;; Works with apply, see #38
+    (should (equal (apply #'ht-get* (list (ht) 1))
+                   nil))))
 
 (ert-deftest ht-test-setf-ht-get ()
   (let ((test-table (ht (1 "one"))))


### PR DESCRIPTION
Using prog1 would return the initial value of the table argument. The modified
value of the table must be returned manually instead.

Fixes #38