### PR TITLE
Make nested ht comparable

### DIFF
--- a/ht.el
+++ b/ht.el
@@ -325,8 +325,11 @@ Does not compare equality predicates."
         (sentinel (make-symbol "ht-sentinel")))
     (and (equal (length keys1) (length keys2))
          (--all?
-          (equal (ht-get table1 it)
-                 (ht-get table2 it sentinel))
+          (if (ht-p (ht-get table1 it))
+              (ht-equal-p (ht-get table1 it)
+                          (ht-get table2 it))
+            (equal (ht-get table1 it)
+                 (ht-get table2 it sentinel)))
           keys1))))
 
 (defalias 'ht-equal-p 'ht-equal?)

--- a/test/ht-test.el
+++ b/test/ht-test.el
@@ -319,7 +319,9 @@
   (should (not (ht-equal-p (ht (1 2) (3 4)) (ht (1 2)))))
   ;; Nested
   (should (ht-equal-p (ht ("foo" (ht ("bar" "baz"))))
-                      (ht ("foo" (ht ("bar" "baz")))))))
+                      (ht ("foo" (ht ("bar" "baz"))))))
+  (should (ht-equal-p (ht ("foo" (ht ("bar" (ht ("baz" "qux"))))))
+                      (ht ("foo" (ht ("bar" (ht ("baz" "qux")))))))))
 
 (ert-deftest ht-test-two-name-style-predicator ()
   (let ((real-definition (lambda (sym)

--- a/test/ht-test.el
+++ b/test/ht-test.el
@@ -316,7 +316,10 @@
   (should (not (ht-equal-p (ht (1 2)) (ht (2 2)))))
   ;; Different amount of keys.
   (should (not (ht-equal-p (ht (1 2)) (ht (1 2) (3 4)))))
-  (should (not (ht-equal-p (ht (1 2) (3 4)) (ht (1 2))))))
+  (should (not (ht-equal-p (ht (1 2) (3 4)) (ht (1 2)))))
+  ;; Nested
+  (should (ht-equal-p (ht ("foo" (ht ("bar" "baz"))))
+                      (ht ("foo" (ht ("bar" "baz")))))))
 
 (ert-deftest ht-test-two-name-style-predicator ()
   (let ((real-definition (lambda (sym)


### PR DESCRIPTION
I was working on an utility that utilizes `ht` and I discovered that `ht-equal-p' always returns nil on nested hash tables. Assuming that nested hash tables *should* be equal, here are the changes with a test.