### PR TITLE
Fix ht-reject! docstring mismatch with actual behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Features
 ### Bug Fixes
 
+* Corrected the documentation for `ht-reject!`.
+
 ## v2.3
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v2.4 (not yet tagged)
 
-No changes yet.
+### Features
+### Bug Fixes
 
 ## v2.3
 

--- a/ht.el
+++ b/ht.el
@@ -292,7 +292,7 @@ FUNCTION is called with two arguments, KEY and VALUE."
     results))
 
 (defun ht-reject! (function table)
-  "Delete entries from TABLE for which FUNCTION returns a falsy value.
+  "Delete entries from TABLE for which FUNCTION returns non-nil.
 
 FUNCTION is called with two arguments, KEY and VALUE."
   (ht-each


### PR DESCRIPTION
The actual behavior is that, when FUNCTION returns non-nil for an entry, the entry is rejected.

Entries are:

- kept when FUNCTION returns falsy (`ht-reject`'s way of describing it), or
- deleted when FUNCTION returns non-nil

and not deleted when it returns falsy.