### PR TITLE
Add ht-update-with!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## v2.4 (not yet tagged)
 
 ### Features
+
+* Added `ht-update-with!`. This is like Racket's `hash-update!`.
+
 ### Bug Fixes
 
 ## v2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v2.4 (not yet tagged)
 
-No changes yet.
+### Features
+### Bug Fixes
 
 ## v2.3
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The missing hash table library for Emacs.
 
 * `ht-set!` `(table key value)`
 * `ht-update!` `(table table)`
+* `ht-update-with!` `(table key updater default?)`
 * `ht-remove!` `(table key)`
 * `ht-clear!` `(table)`
 * `ht-reject!` `(function table)`
@@ -158,6 +159,26 @@ is equivalent to
 ``` emacs-lisp
 (let ((table (ht (1 (ht (2 (ht (3 "three"))))))))
   (setf (ht-get* table 1 2 3) :three))
+```
+
+Updating values with a function using `ht-update-with!`:
+
+``` emacs-lisp
+(let ((table (ht ("a" (list "a" "b")))))
+  (ht-update-with!
+   table "a"
+   (lambda (list)
+     (cons "c" list)))
+  (ht-get table "a")) ; '("c" "a" "b"))
+```
+
+is equivalent to
+
+``` emacs-lisp
+(let ((table (ht ("a" (list "a" "b")))))
+  (setf (ht-get table "a")
+        (cons "c" (ht-get table "a")))
+  (ht-get table "a")) ; '("c" "a" "b"))
 ```
 
 ## Why?

--- a/ht.el
+++ b/ht.el
@@ -132,6 +132,21 @@ for the final key, which may return any value."
 
 (defalias 'ht-update 'ht-update!)
 
+(define-inline ht-update-with! (table key updater &optional default)
+  "Update the value of KEY in TABLE with UPDATER.
+If the value does not exist, do nothing, unless DEFAULT is
+non-nil, in which case act as if the value is DEFAULT.
+
+UPDATER receives one argument, the value, and its return value
+becomes the new value of KEY."
+  (inline-quote
+   (let* ((not-found-symbol (make-symbol "ht--not-found"))
+          (v (gethash ,key ,table
+                      (or ,default not-found-symbol))))
+     (unless (eq v not-found-symbol)
+       (prog1 nil
+         (puthash ,key (funcall ,updater v) ,table))))))
+
 (defun ht-merge (&rest tables)
   "Crete a new tables that includes all the key-value pairs from TABLES.
 If multiple have tables have the same key, the value in the last

--- a/test/ht-test.el
+++ b/test/ht-test.el
@@ -71,6 +71,23 @@
     (should (equal (ht-get* test-table 1)
                    "alpha"))))
 
+(ert-deftest ht-test-update-with! ()
+  (let ((test-table (ht ("foo" 1))))
+    ;; Do it
+    (ht-update-with! test-table "foo" #'1+)
+    (should
+     (equal (ht-get test-table "foo") 2))
+
+    ;; Keys stay unset
+    (ht-update-with! test-table "bar" #'1+)
+    (should-not
+     (ht-contains? test-table "bar"))
+
+    ;; Default value
+    (ht-update-with! test-table "bar" #'1+ 0)
+    (should
+     (equal (ht-get test-table "bar") 1))))
+
 (ert-deftest ht-test-update ()
   (let ((test-table (ht ("foo" 1))))
     (ht-update test-table (ht ("bar" 2)))


### PR DESCRIPTION
This is like [Racket's `hash-update!`](https://docs.racket-lang.org/reference/hashtables.html#(def._((lib._racket%2Fprivate%2Fmore-scheme..rkt)._hash-update!))).

```emacs-lisp
(let ((table (ht ("a" "HT"))))
  (ht-update-with! table "a" #'downcase)
  (ht-get table "a") ; -> "ht"

  ;; nonexistent values are not added
  (ht-update-with! table "key" #'downcase)
  (ht-get table "key") ; -> nil

  ;; unless a default is provided
  (ht-update-with! table "key" #'downcase "VALUE")
  (ht-get table "key")) ; -> "value"
```

`ht-update!` is already used, so I've opted to call it `ht-update-with!`.

## Why

Without this, using a setf / ht-set! to update a value would require repeatedly `ht-get`-ing the same key. For example:

```emacs-lisp
(let ((table (ht ("a" (list "a" "b")))))
  (setf (ht-get table "a")
        (cons "c" (ht-get table "a")))
  (ht-get table "a")) ; '("c" "a" "b"))
```

With this function, this can be written as:

```emacs-lisp
(let ((table (ht ("a" (list "a" "b")))))
  (ht-update-with!
   table "a"
   (lambda (list)
     (cons "c" list)))
  (ht-get table "a")) ; '("c" "a" "b"))
```

In this case the actual updating is just a `cons`, and `ht-update-with!` made it longer, but when the updating code is more complicated, it becomes easier to read with this function.
